### PR TITLE
Cache

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 0.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- speed up cassandra connections with cache
 
 
 0.0.2 (2018-01-22)

--- a/play_cassandra/providers.py
+++ b/play_cassandra/providers.py
@@ -31,21 +31,22 @@ class CassandraProvider(BaseProvider):
 
         if not hasattr(self.engine, 'play_cassandra'):
             self.engine.play_cassandra = {}
+        play_cassandra = self.engine.play_cassandra
         connection_key = repr(command['connection'])
-        if connection_key not in self.engine.play_cassandra:
-            self.engine.play_cassandra[connection_key] = dict(
+        if connection_key not in play_cassandra:
+            play_cassandra[connection_key] = dict(
                 cluster=Cluster(**connection),
                 sessions={},
             )
-        if keyspace not in self.engine.play_cassandra[connection_key]:
-            cluster = self.engine.play_cassandra[connection_key]['cluster']
-            self.engine.play_cassandra[connection_key][keyspace] = \
+        if keyspace not in play_cassandra[connection_key]['sessions']:
+            cluster = play_cassandra[connection_key]['cluster']
+            play_cassandra[connection_key]['sessions'][keyspace] = \
                 cluster.connect(keyspace)
-        return self.engine.play_cassandra[connection_key][keyspace]
+        return play_cassandra[connection_key]['sessions'][keyspace]
 
     def _teardown(self):
         """ Shutdown all cluster and session open connections """
-        if not hasattr(self.engine, 'play_cassandra'):
+        if hasattr(self.engine, 'play_cassandra'):
             for cluster_dict in self.engine.play_cassandra.values():
                 for session in cluster_dict['sessions'].values():
                     try:

--- a/play_cassandra/providers.py
+++ b/play_cassandra/providers.py
@@ -27,8 +27,9 @@ class CassandraProvider(BaseProvider):
 
     def _get_session(self, command, connection, keyspace):
         """ Get cached session """
-        self.engine.teardown = {}  # TODO to be implemented in pytest-play
-        self.engine.teardown['play_cassandra'] = self._teardown
+        self.engine.teardown = []  # TODO to be implemented in pytest-play
+        if self._teardown not in self.engine.teardown:
+            self.engine.teardown['play_cassandra'] = self._teardown
         if not hasattr(self.engine, 'play_cassandra'):
             self.engine.play_cassandra = {}
         connection_key = repr(command['connection'])

--- a/play_cassandra/providers.py
+++ b/play_cassandra/providers.py
@@ -25,13 +25,13 @@ class CassandraProvider(BaseProvider):
             auth_provider = getattr(auth, auth_type)
         connection['auth_provider'] = auth_provider(**auth_provider_conf)
 
-    def _get_session(self, connection, keyspace):
+    def _get_session(self, command, connection, keyspace):
         """ Get cached session """
         self.engine.teardown = {}  # TODO to be implemented in pytest-play
         self.engine.teardown['play_cassandra'] = self._teardown
         if not hasattr(self.engine, 'play_cassandra'):
             self.engine.play_cassandra = {}
-        connection_key = repr(connection)
+        connection_key = repr(command['connection'])
         if connection_key not in self.engine.play_cassandra:
             self.engine.play_cassandra[connection_key] = dict(
                 cluster=Cluster(**connection),
@@ -61,7 +61,7 @@ class CassandraProvider(BaseProvider):
         cmd = deepcopy(command)
         self._setup_auth_provider(cmd)
         connection = cmd['connection']
-        session = self._get_session(connection, cmd['keyspace'])
+        session = self._get_session(command, connection, cmd['keyspace'])
         results = session.execute(cmd['query'])
         try:
             self._make_variable(command, results=results)

--- a/play_cassandra/providers.py
+++ b/play_cassandra/providers.py
@@ -27,9 +27,8 @@ class CassandraProvider(BaseProvider):
 
     def _get_session(self, command, connection, keyspace):
         """ Get cached session """
-        self.engine.teardown = []  # TODO to be implemented in pytest-play
-        if self._teardown not in self.engine.teardown:
-            self.engine.teardown['play_cassandra'] = self._teardown
+        self.engine.register_teardown_callback(self._teardown)
+
         if not hasattr(self.engine, 'play_cassandra'):
             self.engine.play_cassandra = {}
         connection_key = repr(command['connection'])

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('CHANGES.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'pytest-play>=1.2.0',
+    'pytest-play>=1.3.0',
     'cassandra-driver',
 ]
 

--- a/tests/test_play_cassandra.py
+++ b/tests/test_play_cassandra.py
@@ -11,11 +11,11 @@ def variables():
     return {'skins': {'skin1': {'base_url': 'http://', 'credentials': {}}}}
 
 
-def test_provider():
+def test_provider(play_json):
     from play_cassandra import providers
     import mock
-    provider = providers.CassandraProvider(None)
-    assert provider.engine is None
+    provider = providers.CassandraProvider(play_json)
+    assert provider.engine is play_json
     command = {
         'provider': 'play_cassandra',
         'type': 'execute',
@@ -39,9 +39,9 @@ def test_provider():
                 username=command['connection']['auth_provider']['username'],
                 password=command['connection']['auth_provider']['password']
             ) is None
-            connect = cluster.return_value.__enter__.return_value.connect
+            connect = cluster.return_value.connect
             assert connect.assert_called_once_with(command['keyspace']) is None
-            execute = connect.return_value.__enter__.return_value.execute
+            execute = connect.return_value.execute
             assert execute.assert_called_once_with(command['query']) is None
 
 
@@ -74,9 +74,9 @@ def test_provider_assertion_true(play_json):
                 username=command['connection']['auth_provider']['username'],
                 password=command['connection']['auth_provider']['password']
             ) is None
-            connect = cluster.return_value.__enter__.return_value.connect
+            connect = cluster.return_value.connect
             assert connect.assert_called_once_with(command['keyspace']) is None
-            execute = connect.return_value.__enter__.return_value.execute
+            execute = connect.return_value.execute
             assert execute.assert_called_once_with(command['query']) is None
 
 
@@ -110,9 +110,9 @@ def test_provider_assertion_false(play_json):
                 username=command['connection']['auth_provider']['username'],
                 password=command['connection']['auth_provider']['password']
             ) is None
-            connect = cluster.return_value.__enter__.return_value.connect
+            connect = cluster.return_value.connect
             assert connect.assert_called_once_with(command['keyspace']) is None
-            execute = connect.return_value.__enter__.return_value.execute
+            execute = connect.return_value.execute
             assert execute.assert_called_once_with(command['query']) is None
 
 
@@ -147,9 +147,9 @@ def test_provider_variable(play_json):
                 username=command['connection']['auth_provider']['username'],
                 password=command['connection']['auth_provider']['password']
             ) is None
-            connect = cluster.return_value.__enter__.return_value.connect
+            connect = cluster.return_value.connect
             assert connect.assert_called_once_with(command['keyspace']) is None
-            execute = connect.return_value.__enter__.return_value.execute
+            execute = connect.return_value.execute
             assert execute.assert_called_once_with(command['query']) is None
             assert 'user' in play_json.variables
             assert play_json.variables['user'] is execute.return_value[0]
@@ -188,9 +188,9 @@ def test_provider_variable_assertion_false(play_json):
                 username=command['connection']['auth_provider']['username'],
                 password=command['connection']['auth_provider']['password']
             ) is None
-            connect = cluster.return_value.__enter__.return_value.connect
+            connect = cluster.return_value.connect
             assert connect.assert_called_once_with(command['keyspace']) is None
-            execute = connect.return_value.__enter__.return_value.execute
+            execute = connect.return_value.execute
             assert execute.assert_called_once_with(command['query']) is None
             assert 'user' in play_json.variables
             assert play_json.variables['user'] is execute.return_value[0]

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands=flake8 play_cassandra
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
+    -egit+git@github.com:tierratelematics/pytest-play.git@teardown#egg=pytest-play
     -e.[tests]
 commands =
     pip install -U pip setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ commands=flake8 play_cassandra
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    -egit+git@github.com:tierratelematics/pytest-play.git@teardown#egg=pytest-play
     -e.[tests]
 commands =
     pip install -U pip setuptools


### PR DESCRIPTION
Speed up test executions caching very expensive cluster and sessions. Teardown will occur at the end of life of play_json fixture (scope=function)